### PR TITLE
Feat/super admin basic endpoint creation to change role

### DIFF
--- a/apps/http/src/routes/v1/index.ts
+++ b/apps/http/src/routes/v1/index.ts
@@ -5,6 +5,7 @@ import { Router } from "express"
 import bcrypt  from "bcrypt";
 import dotenv from 'dotenv';
 import jwt from "jsonwebtoken"
+import { supRouter } from './super_admin';
 
 dotenv.config();
 
@@ -96,5 +97,7 @@ router.post('/signup', async (req,res) =>{
     }
 
 })
+
+router.use("/sup", supRouter)
 
 

--- a/apps/http/src/routes/v1/index.ts
+++ b/apps/http/src/routes/v1/index.ts
@@ -60,8 +60,6 @@ router.post('/signup', async (req,res) =>{
     }
 
 })
-
-router.use("/sup", supRouter)
 router.post('/signin', async (req,res) =>{
     const signinData = signinSchema.safeParse(req.body);
     if(!signinData.success){
@@ -97,3 +95,5 @@ router.post('/signin', async (req,res) =>{
     }
 
 })
+
+router.use("/sup", supRouter)

--- a/apps/http/src/routes/v1/super_admin/index.ts
+++ b/apps/http/src/routes/v1/super_admin/index.ts
@@ -10,16 +10,13 @@ import { rolesEnumSchema } from "@repo/shared-schema/sharedSchema";
 export const supRouter : Router = Router();
 
 supRouter.put('/change-role/:userName', authMiddleware,verifyRoleMiddleware(["SUPER_ADMIN"]), async(req, res) => {
-    const targetRole = req.body.role;
-    if(!targetRole){
-        res.status(400).json({"error": "Role is required"})
+    const parsedBody = rolesEnumSchema.safeParse(req.body);
+    if(!parsedBody.success) {
+        res.status(400).json({"error": "Invalid role format"})
         return
     }
-    const zodRole = rolesEnumSchema.safeParse(targetRole)
-    if(!zodRole.success){
-        res.status(400).json({"error": "role type is not correct"})
-        return
-    }
+    const targetRole = parsedBody.data.role;
+    
     const userName = req.params.userName;
     try {
         const targetUser = await prisma.user.findUnique({

--- a/apps/http/src/routes/v1/super_admin/index.ts
+++ b/apps/http/src/routes/v1/super_admin/index.ts
@@ -1,0 +1,42 @@
+
+import { Router } from "express";
+import { authMiddleware } from "../../../middleware/authMiddleware";
+import { prisma } from "@repo/db/client";
+
+
+
+export const supRouter : Router = Router();
+
+supRouter.put('/change-role/:userName', authMiddleware, async(req, res) => {
+    const targetRole = req.body.role;
+    const userName = req.params.userName;
+    try {
+        const targetUser = await prisma.user.findUnique({
+            where:
+            {userName}
+        })
+        if(!targetUser){
+            res.status(404).json({"error": "User not found"})
+            return
+        }
+        if(targetRole === targetUser.role){
+            res.status(400).json({"error": "User already has this role"})
+            return
+        }
+        try {
+            const newUser = await prisma.user.update({
+                where:
+                {userName},
+                data: {role: targetRole}
+            })
+            res.status(200).json({"message": "Role changed successfully", 'oldRole': targetUser.role, 'updatedRole':newUser.role})
+            
+        } catch (error) {
+            res.status(500).json({"Internal error: unable to update user in DB": error})
+        }
+    } catch (error) {
+        res.status(500).json({"Internal error": error})
+    }
+
+
+})

--- a/packages/shared-schema/src/index.ts
+++ b/packages/shared-schema/src/index.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
- export const signinSchema = z.object({
-    email: z.string().email(),
-    password: z.string().min(8),
-  });
+export const signinSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
 
-  export const signupSchema = z.object({
-    email: z.string().email(),
-    userName: z.string().min(3).max(10),
-    password: z.string().min(8),
-  });
+export const signupSchema = z.object({
+  email: z.string().email(),
+  userName: z.string().min(3).max(10),
+  password: z.string().min(8),
+});
+
+export const rolesEnumSchema = z.enum(["ADMIN","USER","SUPER_ADMIN"]);

--- a/packages/shared-schema/src/index.ts
+++ b/packages/shared-schema/src/index.ts
@@ -3,12 +3,14 @@ import { z } from "zod";
 export const signinSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-});
+}).strict();
 
 export const signupSchema = z.object({
   email: z.string().email(),
-  userName: z.string().min(3).max(10),
+  userName: z.string().min(3).max(15),
   password: z.string().min(8),
-});
+}).strict();
 
-export const rolesEnumSchema = z.enum(["ADMIN","USER","SUPER_ADMIN"]);
+export const rolesEnumSchema = z.object({
+  role: z.enum(["ADMIN","USER","SUPER_ADMIN"])
+}).strict();


### PR DESCRIPTION
fixes #19 
created change role PUT endpoint: api/v1/sup/change-role/:username
1. Only SUPER_ADMIN can access this route
2. the SUPER_ADMIN has to pass only the role in the request body and roles can only be "ADMIN", "USER "or "SUPER_ADMIN" at this moment.
3. UserName passed through query param should exist
4. If you are trying to change the role of a user to his existing role, it'd return like this: {
    "error": "User is already ADMIN"
}
5. Response looks like: {
    "message": "Role changed successfully",
    "oldRole": "USER",
    "updatedRole": "ADMIN"
}

Other minor changes:
1. in zod schema, made all the schemas strict
2. Username can now contain up to 15 characters